### PR TITLE
Write script-beginning-line with double quotes

### DIFF
--- a/how_to_do_things_safely_in_bash.md
+++ b/how_to_do_things_safely_in_bash.md
@@ -132,7 +132,7 @@ How to begin a bash script
 Something like this:
 
     #!/usr/bin/env bash
-    if test "$BASH" = "" || "$BASH" -uc 'a=();true "${a[@]}"' 2>/dev/null; then
+    if test "$BASH" = "" || "$BASH" -uc "a=();true \"\${a[@]}\"" 2>/dev/null; then
         # Bash 4.4, Zsh
         set -euo pipefail
     else


### PR DESCRIPTION
So `shellcheck` doesn't complain about it.

    $shellcheck demo.sh 
    In demo.sh line 2:
    if test "$BASH" = "" || "$BASH" -uc 'a=();true "${a[@]}"' 2>/dev/null; then
                                        ^-- SC2016: Expressions don't expand in single quotes, use double quotes for that.