### PR TITLE
Fix bash -c example, $0 is also specified on the cmdline

### DIFF
--- a/how_to_do_things_safely_in_bash.md
+++ b/how_to_do_things_safely_in_bash.md
@@ -610,11 +610,15 @@ Good (C/POSIX), minus error handling:
 If the shell is needed, let arguments be arguments. You might think this was cumbersome – writing a special-purpose shellscript to its own file and invoking that – until you have seen this trick:
 
 * Bad (python3): `subprocess.check_call('docker exec {} bash -ec "printf %s {} > {}"'.format(instance, content, path))`
-* Good (python3): `subprocess.check_call(['docker', 'exec', instance, 'bash', '-ec', 'printf %s "$0" > "$1"', content, path])`
+* Good (python3): `subprocess.check_call(['docker', 'exec', instance, 'bash', '-ec', 'printf %s "$0" > "$1"', , 'bash', content, path])`
 
 Can you spot the shellscript?
 
 That's right, the printf command with the redirection. Note the correctly quoted numbered arguments. Embedding a static shellscript is fine.
+
+Note that the second argument to `bash -c` is bound to `$0` not `$1` as a
+any reasonable person would expect. We simply set that to "bash" here but
+you can use whatever you want.
 
 The examples run in Docker because they wouldn't be as useful otherwise, but Docker is also a fine example of a command that runs other commands based on arguments. This is unlike Ssh, as we will see.
 


### PR DESCRIPTION
Notice how the following only prints 2 and 3

    bash -c 'printf "%s\n" "$@"' 1 2 3
    2
    3

because 1 is absorbed into $0:

    bash -c 'printf "%s\n" "$0" "$@"' 1 2 3
    1
    2
    3