### PR TITLE
(feat) dockerize shellharden

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.51.0-alpine AS build
+
+WORKDIR /src
+RUN apk add --no-cache git
+COPY . .
+RUN cargo build --release
+
+FROM alpine:3.13.2 AS alpine
+COPY --from=build /src/target/release/shellharden /bin/shellharden
+COPY "./docker-entrypoint.sh" "/init"
+ENTRYPOINT ["/init"]
+
+FROM scratch
+COPY --from=build /src/target/release/shellharden  /bin/shellharden
+ENTRYPOINT ["/bin/shellharden"]
+CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 Shellharden
 ===========
 
-Shellharden is a syntax highlighter and a tool to semi-automate the rewriting
-of scripts to ShellCheck conformance, mainly focused on quoting.
+Shellharden is a syntax highlighter and a tool to semi-automate the rewriting of
+scripts to ShellCheck conformance, mainly focused on quoting.
 
 The default mode of operation is like `cat`, but with syntax highlighting in
 foreground colors and suggestive changes in background colors:
@@ -15,38 +15,48 @@ foreground colors and suggestive changes in background colors:
 
 Above: Selected portions of `xdg-desktop-menu` as highlighted by Shellharden.
 The foreground colors are syntax highlighting, whereas the background colors
-(green and red) show characters that Shellharden would have added or removed
-if let loose with the `--transform` option.
-Below: An artificial example that shows more tricky cases and special features.
+(green and red) show characters that Shellharden would have added or removed if
+let loose with the `--transform` option. Below: An artificial example that shows
+more tricky cases and special features.
 
 ![artificial example](img/ex-artificial.png)
 
 Why
 ---
 
-A variable in bash is like a hand grenade – take off its quotes, and it starts ticking. Hence, rule zero of [bash pitfalls][1]: Always use quotes.
+A variable in bash is like a hand grenade – take off its quotes, and it starts
+ticking. Hence, rule zero of [bash pitfalls][1]: Always use quotes.
 
 Name
 ----
 
 Shellharden can do what Shellcheck can't: Apply the suggested changes.
 
-In other words, harden brittle shellscripts.
-The builtin assumption is that the script does not *depend* on the brittle behavior –
-the user is responsible for the code review.
+In other words, harden brittle shellscripts. The builtin assumption is that the
+script does not *depend* on the brittle behavior – the user is responsible for
+the code review.
 
-Shellharden was previously known as "Naziquote".
-In the right jargon, that was the best name ever,
-but oh so misleading and unspeakable to outsiders.
+Shellharden was previously known as "Naziquote". In the right jargon, that was
+the best name ever, but oh so misleading and unspeakable to outsiders.
 
-I couldn't call it "bash cleaner" either, as that means "poo smearer" in Norwegian.
+I couldn't call it "bash cleaner" either, as that means "poo smearer" in
+Norwegian.
 
 Prior art
 ---------
 
-* [Shellcheck][2] is a wonderful tool to *detect*, and give general advice, about brittle bash code. The only thing missing is something to say yes with, and *apply* those advice (assuming proper review of course).
+* [Shellcheck][2] is a wonderful tool to *detect* and give general advice about
+  brittle bash code. The only thing missing is something to say yes with, and
+  *apply* that advice (assuming proper review, of course).
 
-* I asked [this SO question][3], for a tool that could rewrite bash scripts with proper quoting. One answerer beat me to it. But if it was me, I would do a syntax highlighter in the same tool (as a way to see if the parser gets lost, and make the most out of the parser, because bash is like quantum mechanics – nobody really knows how it works).
+* I asked [this SO question][3] for a tool that could rewrite bash scripts with
+  proper quoting. One answerer beat me to it. But if it were me, I would do a
+  syntax highlighter in the same tool (as a way to see if the parser gets lost,
+  and make the most out of the parser, because bash is like quantum mechanics –
+  nobody really knows how it works).
+
+Usage
+=====
 
 Get it
 ------
@@ -66,28 +76,52 @@ Build from source
 
     cargo build --release
 
-### Run tests
+Run tests
+---------
 
     cargo test --release
 
 (requires bash)
 
-### Install
+Install
+--------
 
     cp target/release/shellharden /usr/local/bin/
 
-### Fuzz test
+Fuzz test
+---------
 
     cargo install afl
     cargo afl build --release
     cargo afl fuzz -i moduletests/original -o /tmp/fuzz-shellharden target/release/shellharden '@@'
 
+Docker
+------
+
+Build the Docker image:
+
+    docker build -t my:tag -f Dockerfile .
+
+This creates an image that only includes shellharden. Alternatively, if you want an image that includes alpine, add --target alpine. To use the Docker image, run:
+
+    docker run --rm -v $PWD:/mnt -w /mnt my:tag <shellharden arguments>
+
 Usage advice
 ------------
 
-Don't apply `--transform` blindly; code review is still necessary: A script that *relies* on unquoted behavior (implicit word splitting and glob expansion from variables and command substitutions) to work as intended will do none of that after getting the `--transform` treatment!
+Don't apply `--transform` blindly; code review is still necessary: A script that
+*relies* on unquoted behavior (implicit word splitting and glob expansion from
+variables and command substitutions) to work as intended will do none of that
+after getting the `--transform` treatment!
 
-In that unlucky case, ask yourself whether the script has any business in doing that. All too often, it's just a product of classical shellscripting, and would be better off rewritten, such as by using arrays. Even in the opposite case, say the business logic involves word splitting; that can still be done without invoking globbing. In short: There is always a better way than the forbidden syntax (if not more explicit), but some times, a human must step in to rewrite. See how, in the accompanying [how to do things safely in bash](how_to_do_things_safely_in_bash.md).
+In that unfortunate case, ask yourself whether the script has any business in
+doing that. All too often, it's just a product of classical shell scripting and
+would be better off rewritten, such as by using arrays. Even in the opposite
+case, say the business logic involves word splitting, that can still be done
+without invoking globbing. In short: There is always a better way than the
+forbidden syntax (if not more explicit), but sometimes, a human must step in to
+rewrite. See how in the accompanying [how to do things safely in
+bash](how_to_do_things_safely_in_bash.md).
 
 [1]: http://mywiki.wooledge.org/BashPitfalls
 [2]: https://www.shellcheck.net/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -gt 0 ] \
+    && [ "${1#-}" = "${1}" ] \
+    && command -v "${1}" > "/dev/null" 2>&1; then
+    exec "${@}"
+else
+    exec /bin/shfmt "${@}" # else default to run the command
+fi
+exit 0


### PR DESCRIPTION
Enables a user to run `shellharden` in a Docker
container.

- Add Dockerfile & entrypoint
- Update README.md
    - Add Docker usage
    - Wrap lines to make it easier to read from CLI
    - Correct misc. grammar & punctuation

I did this so I can use it in a CI/CD pipeline, but thought
it might be worth contributing back. If you want, I can publish
it to docker hub before you accept this PR.

Thanks for such a great tool!

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>