### PR TITLE
feature: add Dockerfiles alpine

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,57 @@
+FROM rust:alpine AS bootstrap_os
+  # hadolint ignore=DL3018
+  RUN apk upgrade --update-cache --available
+
+
+FROM bootstrap_os AS bootstrap_build_deps
+  # hadolint ignore=DL3018
+  RUN apk add --no-cache --virtual .rust-builder cmake clang musl-dev make pkgconfig
+
+
+FROM bootstrap_build_deps AS bootstrap_builder
+  ENV RUST_BACKTRACE=1
+
+  RUN cargo install shellharden --message-format short && apk del .rust-builder
+
+
+FROM alpine:3.13.3 AS pipeline
+  # hadolint ignore=SC2016
+  RUN apk upgrade --update-cache --available \
+      && { \
+        echo '#!/bin/sh'; \
+        echo 'set -eu'; \
+        echo 'if [ "${#}" -gt 0 ] && [ "${1#-}" = "${1}" ] \'; \
+        echo '  && command -v "${1}" > "/dev/null" 2>&1; then'; \
+        echo '  exec "${@}"'; \
+        echo 'else exec /bin/shfmt "${@}"; fi'; \
+        echo 'exit 0'; \
+      } > /init && chmod +x /init
+
+  COPY --from=bootstrap_builder /usr/local/cargo/bin/shellharden /usr/local/cargo/bin/
+
+  WORKDIR /usr/local/cargo/bin
+
+  SHELL [ "/bin/ash", "-o", "pipefail", "-c" ]
+
+  RUN find . -type f -executable -not \( -name '*tkinter*' \) -exec ldd '{}' ';' \
+      | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); gsub(".*/", "", so); print so }' \
+      | xargs -r apk search -f | awk '{ so = $(NF-1); gsub(/-\d+.*$/, "", so); print so }' \
+      | xargs -r apk add --no-cache --virtual .runtime
+
+  ENV PATH="/usr/local/cargo/bin:${PATH}"
+
+  WORKDIR /root
+
+  RUN shellharden --version
+
+  ENTRYPOINT [ "/init" ]
+
+
+FROM scratch
+  COPY --from=bootstrap_builder /usr/local/cargo/bin/ /bin/
+
+  ENTRYPOINT [ "/bin/shellharden" ]
+
+  CMD [ "-h" ]
+
+# vi: nospell

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -52,6 +52,6 @@ FROM scratch
 
   ENTRYPOINT [ "/bin/shellharden" ]
 
-  CMD [ "-h" ]
+  CMD [ "shellharden", "-h" ]
 
 # vi: nospell

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,21 @@
+h2. Build the Docker image:
+
+```sh
+  docker build -t shellharden:my_tag -f Dockerfile .
+```
+
+This creates an image that only includes shellharden.
+
+h2. Build the Docker image:
+
+```sh
+  docker build -t shellharden:my_tag -f Dockerfile . --target=pipeline
+```
+
+This creates an alpine image that includes /usr/local/cargo/bin/shellharden
+
+h2. Use the Docker image:
+
+```sh
+  docker run --rm -v $PWD:/mnt -w /mnt shellharden:my_tag <shellharden arguments>
+```


### PR DESCRIPTION
Inspired by https://github.com/anordal/shellharden/pull/41#issuecomment-820783219

Provides alpine dockerfile within the `docker/` path, and independent `docker/README.md` file.
Includes `/init` build artifact within build.
Includes OS updating to reduce security concerns.
Includes backtracing builds by default to improve developer experience when-if something fails to compile.