### PR TITLE
Update Dockerfile Rust base image to 1.92.0-alpine

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # docker build . -f docker/Dockerfile --tag shellharden:latest
 
 
-FROM rust:1.53.0-alpine AS build
+FROM rust:1.92.0-alpine AS build
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
Rust 1.53 (released on 2021-06-17) is far beyond the support window. Rust only supports the latest stable plus beta/nightly, so update the build image to the current stable toolchain.

References:
- https://rust-lang.org/policies/security
- https://doc.rust-lang.org/stable/releases.html